### PR TITLE
Fix element selector generator for svg and path

### DIFF
--- a/src/shared/config/template.js
+++ b/src/shared/config/template.js
@@ -133,29 +133,50 @@ module.exports = {
     },
     getElementSelector: {
         value: (input) => {
-            function getXPathForElement(element) {
-                const idx = (sibling, name) =>
-                    sibling
-                        ? idx(sibling.previousElementSibling, name || sibling.localName) +
-                          (sibling.localName == name)
-                        : 1;
+            function getTagSelector(tagName) {
+                const tag = tagName.toLowerCase();
 
-                const segs = (element) => {
-                    if (!element || element.nodeType !== 1) {
-                        return [''];
-                    } else {
-                        return element.id && document.getElementById(element.id) === element
-                            ? [`id("${element.id}")`]
-                            : [
-                                  ...segs(element.parentNode),
-                                  `${element.localName.toLowerCase()}[${idx(element)}]`,
-                              ];
-                    }
-                };
-                return segs(element).join('/');
+                // Some tag names cannot be simply selected by xpath
+                if (['svg', 'path'].includes(tag)) {
+                    return `*[local-name() = '${tag}']`;
+                }
+
+                return tag;
             }
 
-            return getXPathForElement(input);
+            function getPathTo(element) {
+                if (element === document.body) {
+                    return '//' + element.tagName.toLowerCase();
+                }
+
+                if (!element.parentNode) {
+                    return '/';
+                }
+
+                var siblings = element.parentNode.childNodes;
+                var index = 0;
+
+                for (var i = 0; i < siblings.length; i++) {
+                    var sibling = siblings[i];
+
+                    if (sibling === element) {
+                        return (
+                            getPathTo(element.parentNode) +
+                            '/' +
+                            getTagSelector(element.tagName) +
+                            '[' +
+                            (index + 1) +
+                            ']'
+                        );
+                    }
+
+                    if (sibling.nodeType === 1 && sibling.tagName === element.tagName) {
+                        index++;
+                    }
+                }
+            }
+
+            return getPathTo(input);
         },
         description: 'Script executed in browser context, which should generate unique element selector',
         type: 'Function',


### PR DESCRIPTION
Selected a different approach to generate selectors for elements, since `svg` and `path` tags cannot be searched by the same way as other tag names via xpath for some reason.

Also changed the behaviour for situations, where there is no parent element. Since this should never occur for QApe (it stops at body element, which still has a parent), we will use double slash (`//`), instead of single slash (`/`), whenever there is no parent element. This should solve situations, where parent element is not defined for some reason and the element selector generator would think, that this is the full path, but in reality it is not.